### PR TITLE
fix PerformPromiseAny semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -74,8 +74,8 @@ contributors: Mathias Bynens, Kevin Gibbons, Sergey Rubanov
           1. Set _iteratorRecord_.[[Done]] to *true*.
           1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
           1. If _remainingElementsCount_.[[Value]] is 0, then
-            1. Let _valuesArray_ be CreateArrayFromList(_values_).
-            1. Perform ? Call(_resultCapability_.[[Reject]], *undefined*, &laquo; _valuesArray_ &raquo;).
+            1. Let _errorsArray_ be CreateArrayFromList(_errors_).
+            1. Perform ? Call(_resultCapability_.[[Reject]], *undefined*, &laquo; _errorsArray_ &raquo;).
           1. Return _resultCapability_.[[Promise]].
         1. Let _nextValue_ be IteratorValue(_next_).
         1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.

--- a/spec.html
+++ b/spec.html
@@ -112,8 +112,9 @@ contributors: Mathias Bynens, Kevin Gibbons, Sergey Rubanov
       1. Set _errors_[_index_] to _x_.
       1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
       1. If _remainingElementsCount_.[[Value]] is 0, then
-        1. Let _errorsArray_ be CreateArrayFromList(_errors_).
-        1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _errorsArray_ &raquo;).
+        1. Let _error_ be a newly created `AggregateError` object.
+        1. Perform ! CreateDataProperty ( _error_, `"errors"`, _errorsArray_ ).
+        1. Return ThrowCompletion ( _error_ ).
       1. Return *undefined*.
     </emu-alg>
     <p>The `"length"` property of a `Promise.any` resolve element function is 1.</p>

--- a/spec.html
+++ b/spec.html
@@ -74,8 +74,9 @@ contributors: Mathias Bynens, Kevin Gibbons, Sergey Rubanov
           1. Set _iteratorRecord_.[[Done]] to *true*.
           1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
           1. If _remainingElementsCount_.[[Value]] is 0, then
-            1. Let _errorsArray_ be CreateArrayFromList(_errors_).
-            1. Perform ? Call(_resultCapability_.[[Reject]], *undefined*, &laquo; _errorsArray_ &raquo;).
+            1. Let _error_ be a newly created `AggregateError` object.
+            1. Perform ! CreateDataProperty ( _error_, `"errors"`, _errorsArray_ ).
+            1. Return ThrowCompletion ( _error_ ).
           1. Return _resultCapability_.[[Promise]].
         1. Let _nextValue_ be IteratorValue(_next_).
         1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.

--- a/spec.html
+++ b/spec.html
@@ -72,6 +72,10 @@ contributors: Mathias Bynens, Kevin Gibbons, Sergey Rubanov
         1. ReturnIfAbrupt(_next_).
         1. If _next_ is *false*, then
           1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
+          1. If _remainingElementsCount_.[[Value]] is 0, then
+            1. Let _valuesArray_ be CreateArrayFromList(_values_).
+            1. Perform ? Call(_resultCapability_.[[Reject]], *undefined*, &laquo; _valuesArray_ &raquo;).
           1. Return _resultCapability_.[[Promise]].
         1. Let _nextValue_ be IteratorValue(_next_).
         1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.


### PR DESCRIPTION
Fix three points from #27:

> In PerformPromiseAny step 8.d you also need to include (the equivalent of) steps ii and iii from 8.d of PerformPromiseAll. Otherwise remainingElementsCount can never reach 0 - it starts at 1, is incremented each turn of the loop, and is decremented at most once per turn of the loop. (Starting remainingElementsCount at 0 wouldn't work for a more subtle reason.)

> No provision is made for empty iterables. Fixing the preceding item in this list would also fix this.

> When Promise.any rejects, it does so with a bare array of errors, not an AggregateError containing that array.