### PR TITLE
remove AggregateError.prototype.errors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -170,11 +170,6 @@ contributors: Mathias Bynens, Kevin Gibbons, Sergey Rubanov
         <p>The initial value of `AggregateError.prototype.name` is `"AggregateError"`.</p>
       </emu-clause>
 
-      <emu-clause id="sec-aggregate-error.prototype.errors">
-        <h1>_AggregateError_.prototype.errors</h1>
-        <p>The initial value of `AggregateError.prototype.errors` is an empty Array.</p>
-      </emu-clause>
-
       <emu-clause id="sec-aggregate-error.prototype.toString">
         <h1>_AggregateError_.prototype.toString ( )</h1>
         <p>The following steps are taken:</p>


### PR DESCRIPTION
I very strongly agree with @ljharb's [comment](https://github.com/tc39/proposal-promise-any/pull/37#discussion_r328242050) that we should not introduce a mutable data property on a prototype. We can just not do that instead.